### PR TITLE
chore: modernize GitHub Actions workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: "Build"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,6 +7,9 @@ on:
   schedule:
     - cron: "0 8 * * 1"
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- update deprecated GitHub Action majors in workflow definitions (including actions/cache to v4)
- modernize Docker action majors to supported versions
- add explicit least-privilege workflow permissions (contents: read)

## Why
- prevent failures from deprecated action versions and keep CI workflows supportable
- make workflow token permissions explicit and minimal while preserving behavior