### PR TITLE
Add CI rollout baseline

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   build:
     name: "Build"
+    if: github.event.workflow_run.head_branch == 'master' && github.event.workflow_run.conclusion == 'success'
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,9 +15,9 @@ jobs:
     uses: dockette/.github/.github/workflows/docker.yml@master
     secrets: inherit
     with:
-        image: "dockette/vagrant"
-        tag: "${{ matrix.item }}"
-        context: "${{ matrix.item }}"
+      image: "dockette/vagrant"
+      tag: "${{ matrix.item }}"
+      context: "${{ matrix.item }}"
     strategy:
       matrix:
         include:
@@ -29,3 +29,20 @@ jobs:
           - item: "debian-11-systemd"
 
       fail-fast: false
+
+  docs:
+    name: "Docs"
+    runs-on: "ubuntu-latest"
+    needs: ["build"]
+    if: github.event.workflow_run.head_branch == 'master'
+
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v6
+
+      - name: "Update Docker Hub description"
+        uses: peter-evans/dockerhub-description@v5
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: "dockette/vagrant"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+## Project
+
+Docker image repository in the Dockette organization.
+
+## Commands
+
+- `make build` builds the default Docker image.
+- `make test` runs the repository smoke tests.
+- `make run` starts the image for local use.
+
+## Guidelines
+
+- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Prefer `DOCKER_*` names for Docker-related Makefile variables.
+- Place `.PHONY: <target>` directly above each Makefile target.
+- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Do not introduce unrelated formatting or structural changes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,18 +2,35 @@
 
 ## Project
 
-Docker image repository in the Dockette organization.
+Dockette Vagrant publishes Docker images that behave like Vagrant boxes, including SSH-ready Debian images and systemd-enabled variants for Vagrant's Docker provider or direct Docker use.
+
+## Images
+
+- Docker image: `dockette/vagrant`.
+- Default Makefile tag: `debian-13-systemd`.
+- Makefile build contexts: `debian-13`, `debian-13-systemd`, `debian-12`, `debian-12-systemd`, `debian-11`, `debian-11-systemd`, `debian-10`, `debian-10-systemd`.
+- Workflow publish matrix currently includes Debian 13, 12, and 11 contexts only.
+- Plain variants run `sshd -D`; `*-systemd` variants run `/lib/systemd/systemd` and declare `/sys/fs/cgroup` as a volume.
 
 ## Commands
 
-- `make build` builds the default Docker image.
-- `make test` runs the repository smoke tests.
-- `make run` starts the image for local use.
+- `make build` builds all Makefile-listed image contexts with Docker Buildx.
+- `make test` runs `vagrant validate` against `Vagrantfile`.
+- `make run` starts `${DOCKER_IMAGE}:${DOCKER_TAG}` with the privileges needed for systemd.
+- `make run-debian-12-systemd` and `make run-debian-13-systemd` start explicit systemd images.
+- Override `DOCKER_TAG`, `DOCKER_IMAGE`, or `DOCKER_PLATFORMS` when checking a specific image or platform.
+
+## Runtime Notes
+
+- There are no compose files in this repository.
+- Systemd images require `--privileged`, `--cgroupns=host`, and `-v /sys/fs/cgroup:/sys/fs/cgroup:rw`.
+- The default Makefile platform is `linux/arm64`; keep that in mind when building on amd64 hosts.
+- `Vagrantfile` uses the Docker provider by default and tests SSH/provisioning behavior through Vagrant and Ansible in CI.
 
 ## Guidelines
 
-- Keep Dockerfiles, `Makefile`, README, and GitHub Actions workflow changes aligned.
+- Keep Dockerfiles, README image lists, Makefile targets, `Vagrantfile`, and workflow matrices aligned when changing supported Debian versions.
 - Prefer `DOCKER_*` names for Docker-related Makefile variables.
 - Place `.PHONY: <target>` directly above each Makefile target.
-- Keep README badges and maintenance sections consistent with other Dockette image repos.
+- Preserve the `vagrant` user, passwordless sudo, authorized key setup, SSH port exposure, and cleanup behavior unless intentionally changing box semantics.
 - Do not introduce unrelated formatting or structural changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,15 @@
 DOCKER_IMAGE=dockette/vagrant
 DOCKER_PLATFORM?=linux/arm64
 
-.PHONY: build-all
+.PHONY: build test run build-all
+
+build: build-all
+
+test:
+	vagrant validate
+
+run: run-debian-13-systemd
+
 build-all: build-debian-13 build-debian-13-systemd build-debian-12 build-debian-12-systemd build-debian-11 build-debian-11-systemd build-debian-10 build-debian-10-systemd
 
 .PHONY: build-debian-13

--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,15 @@ DOCKER_IMAGE=dockette/vagrant
 DOCKER_TAG?=debian-13-systemd
 DOCKER_PLATFORMS?=linux/arm64
 
-.PHONY: build test run build-all
 
+.PHONY: build
 build: build-all
 
+.PHONY: test
 test:
 	vagrant validate
 
+.PHONY: run
 run:
 	docker run \
 		-it \
@@ -19,6 +21,7 @@ run:
 		-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 		${DOCKER_IMAGE}:${DOCKER_TAG}
 
+.PHONY: build-all
 build-all: build-debian-13 build-debian-13-systemd build-debian-12 build-debian-12-systemd build-debian-11 build-debian-11-systemd build-debian-10 build-debian-10-systemd
 
 .PHONY: build-debian-13
@@ -46,6 +49,7 @@ build-debian-10: _docker-build-debian-10
 build-debian-10-systemd: _docker-build-debian-10-systemd
 
 _docker-build-%: VERSION=$*
+.PHONY: _docker-build-%
 _docker-build-%:
 	docker buildx \
 		build \
@@ -54,6 +58,7 @@ _docker-build-%:
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./${VERSION}
 
+.PHONY: run-debian-12-systemd
 run-debian-12-systemd:
 	docker run \
 		-it \
@@ -64,6 +69,7 @@ run-debian-12-systemd:
 		-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
 		${DOCKER_IMAGE}:debian-12-systemd
 
+.PHONY: run-debian-13-systemd
 run-debian-13-systemd:
 	docker run \
 		-it \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 DOCKER_IMAGE=dockette/vagrant
-DOCKER_PLATFORM?=linux/arm64
+DOCKER_TAG?=debian-13-systemd
+DOCKER_PLATFORMS?=linux/arm64
 
 .PHONY: build test run build-all
 
@@ -8,7 +9,15 @@ build: build-all
 test:
 	vagrant validate
 
-run: run-debian-13-systemd
+run:
+	docker run \
+		-it \
+		--rm \
+		--platform ${DOCKER_PLATFORMS} \
+		--privileged \
+		--cgroupns=host \
+		-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
+		${DOCKER_IMAGE}:${DOCKER_TAG}
 
 build-all: build-debian-13 build-debian-13-systemd build-debian-12 build-debian-12-systemd build-debian-11 build-debian-11-systemd build-debian-10 build-debian-10-systemd
 
@@ -41,7 +50,7 @@ _docker-build-%:
 	docker buildx \
 		build \
 		--pull \
-		--platform ${DOCKER_PLATFORM} \
+		--platform ${DOCKER_PLATFORMS} \
 		-t ${DOCKER_IMAGE}:${VERSION} \
 		./${VERSION}
 
@@ -49,7 +58,7 @@ run-debian-12-systemd:
 	docker run \
 		-it \
 		--rm \
-		--platform ${DOCKER_PLATFORM} \
+		--platform ${DOCKER_PLATFORMS} \
 		--privileged \
 		--cgroupns=host \
 		-v /sys/fs/cgroup:/sys/fs/cgroup:rw \
@@ -59,7 +68,7 @@ run-debian-13-systemd:
 	docker run \
 		-it \
 		--rm \
-		--platform ${DOCKER_PLATFORM} \
+		--platform ${DOCKER_PLATFORMS} \
 		--privileged \
 		--cgroupns=host \
 		-v /sys/fs/cgroup:/sys/fs/cgroup:rw \

--- a/README.md
+++ b/README.md
@@ -1,17 +1,14 @@
 <h1 align=center>Dockette / Vagrant</h1>
 
 <p align=center>
+   <a href="https://github.com/dockette/vagrant/actions"><img src="https://github.com/dockette/vagrant/actions/workflows/docker.yml/badge.svg" alt="GitHub Actions"></a>
+   <a href="https://hub.docker.com/r/dockette/vagrant"><img src="https://img.shields.io/docker/pulls/dockette/vagrant.svg" alt="Docker Hub pulls"></a>
+   <a href="https://github.com/sponsors/f3l1x"><img src="https://img.shields.io/badge/sponsor-GitHub%20Sponsors-ea4aaa" alt="GitHub Sponsors"></a>
+   <a href="https://github.com/orgs/dockette/discussions"><img src="https://img.shields.io/badge/support-discussions-6f42c1" alt="Support/Discussions"></a>
+</p>
+
+<p align=center>
    Ready-to-use Docker images for Vagrant.
-</p>
-
-<p align=center>
-🕹 <a href="https://f3l1x.io">f3l1x.io</a> | 💻 <a href="https://github.com/f3l1x">f3l1x</a> | 🐦 <a href="https://twitter.com/xf3l1x">@xf3l1x</a>
-</p>
-
-<p align=center>
-  <a href="https://hub.docker.com/r/dockette/vagrant/"><img src="https://badgen.net/docker/pulls/dockette/vagrant"></a>
-  <a href="https://bit.ly/ctteg"><img src="https://badgen.net/badge/support/gitter/cyan"></a>
-  <a href="https://github.com/sponsors/f3l1x"><img src="https://badgen.net/badge/sponsor/donations/F96854"></a>
 </p>
 
 -----
@@ -66,14 +63,12 @@ docker run \
 
 ## Development
 
-See [how to contribute](https://contributte.org/contributing.html) to this package.
+```sh
+make build
+make test
+make run
+```
 
-This package is currently maintaining by these authors.
+## Maintenance
 
-<a href="https://github.com/f3l1x">
-    <img width="80" height="80" src="https://avatars2.githubusercontent.com/u/538058?v=3&s=80">
-</a>
-
------
-
-Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Also thank you for using this package.
+See [how to contribute](https://github.com/dockette/.github/blob/master/CONTRIBUTING.md) to this package. Consider to [support](https://github.com/sponsors/f3l1x) **f3l1x**. Thank you for using this package.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ docker run \
 	dockette/vagrant:debian-13-systemd
 ```
 
-### Images
+### Published Images
 
 - `dockette/vagrant:debian-13`
 - `dockette/vagrant:debian-13-systemd`
@@ -58,8 +58,8 @@ docker run \
 - `dockette/vagrant:debian-12-systemd`
 - `dockette/vagrant:debian-11`
 - `dockette/vagrant:debian-11-systemd`
-- `dockette/vagrant:debian-10`
-- `dockette/vagrant:debian-10-systemd`
+
+The Docker workflow publishes Debian 13, 12, and 11 tags. Debian 10 Dockerfiles remain available for local builds, but Debian 10 tags are not part of the current publish matrix.
 
 ## Development
 
@@ -68,6 +68,16 @@ make build
 make test
 make run
 ```
+
+Makefile defaults:
+
+- `DOCKER_IMAGE=dockette/vagrant`
+- `DOCKER_TAG=debian-13-systemd`
+- `DOCKER_PLATFORMS=linux/arm64`
+
+`make build` builds every Makefile-listed context, including the local Debian 10 contexts. `make test` runs `vagrant validate` only. Full CI validation also starts the Docker provider with `vagrant up --provider=docker` and runs the Ansible checks in `.tests/`.
+
+Override `DOCKER_TAG` to run a different image tag and `DOCKER_PLATFORMS` to target another platform, for example `DOCKER_PLATFORMS=linux/amd64 make build`. The default `linux/arm64` platform may use emulation or fail unexpectedly on amd64 hosts without compatible Buildx/QEMU support.
 
 ## Maintenance
 


### PR DESCRIPTION
What changed
- Added generic Makefile aliases for build, test, and run.
- Added a Docker Hub description Docs job to the Docker workflow.
- Normalized README badges to the dockette/copybara style and added the standard Maintenance section.

Why
- Brings dockette/vagrant in line with the Dockette CI rollout baseline while preserving the existing Vagrant test workflow and Docker build matrix.